### PR TITLE
Mention ViaProxy & Velocity as a alternative for 1.20.3+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,11 @@
 # ViaBungee
 
 > [!WARNING]  
-> This currently only works if **both client and server are below 1.20.2**.
+> This currently only works if **both client and server are below 1.20.2**. for 1.20.3+, it is recommended to use ViaProxy or Switch to Velocity.
 
-See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your
-backend servers or switching to Velocity, as ViaBungee is fairly unstable due to platform limitations.
+See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your backend servers, or switching to Velocity as ViaBungee is Unstable.
+
+If You Still Want to use Bungeecord API or dont want to switch to velocity, Use [ViaProxy](https://github.com/ViaVersion/ViaProxy).
 
 ## To get started
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 > [!WARNING]  
 > This currently only works if **both client and server are below 1.20.2**. for 1.20.3+, it is recommended to use ViaProxy or Switch to Velocity.
 
-See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your backend servers, or switching to Velocity as ViaBungee is Unstable.
+See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your backend servers, or switching to Velocity as ViaBungee is fairly unstable due to platform limitations.
 
 If You Still Want to use Bungeecord API or dont want to switch to velocity, Use [ViaProxy](https://github.com/ViaVersion/ViaProxy).
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,10 @@
 # ViaBungee
 
 > [!WARNING]  
-> This currently only works if **both client and server are below 1.20.2**. for 1.20.3+, it is recommended to use ViaProxy or Switch to Velocity.
+> This currently only works if **both client and server are below 1.20.2**.
 
-See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your backend servers, or switching to Velocity as ViaBungee is fairly unstable due to platform limitations.
-
-If You Still Want to use Bungeecord API or dont want to switch to velocity, Use [ViaProxy](https://github.com/ViaVersion/ViaProxy).
+See https://github.com/ViaVersion/ViaVersion for the main project. Note that we recommend putting ViaVersion on your 
+backend servers, or switching to [Velocity](https://github.com/PaperMC/Velocity) or [ViaProxy](https://github.com/ViaVersion/ViaProxy) as ViaBungee is fairly unstable due to platform limitations.
 
 ## To get started
 


### PR DESCRIPTION
1.20.3+ users have to use velocity but 1.20.3+ Users Can Also use ViaProxy if they want to still use the Bungeecord API(just in case).

